### PR TITLE
faker: use add_sticker

### DIFF
--- a/Items/Consumables/spectral.lua
+++ b/Items/Consumables/spectral.lua
@@ -123,7 +123,7 @@ SMODS.Consumable {
 
             local copy = copy_card(c)
             copy:set_edition("e_negative", true)
-            copy.ability.perishable = true
+            copy:add_sticker("perishable", true)
             G.jokers:emplace(copy)
 
         end


### PR DESCRIPTION
Faker causes crashes because it doesn't set `card.perish_tally`; using `card:add_sticker()` fixes this