### PR TITLE
Fix division by zero error in `ease_dollars` hook

### DIFF
--- a/Items/challenges.lua
+++ b/Items/challenges.lua
@@ -34,7 +34,9 @@ end
 local moneyhook = ease_dollars
 
 function ease_dollars(amount, instant)
-    amount = (math.abs(amount) ^ (G.GAME.money_exponent or 1)) * (amount / math.abs(amount))
+    if amount ~= to_big(0) then
+        amount = (math.abs(amount) ^ (G.GAME.money_exponent or 1)) * (amount / math.abs(amount))
+    end
     moneyhook(amount, instant)
 end
 


### PR DESCRIPTION
Attempting to ease zero dollars was resulting in NaN money (shouldn't _really_ be happening, but)